### PR TITLE
Fixes for integration with zkp.

### DIFF
--- a/src/affine.rs
+++ b/src/affine.rs
@@ -295,8 +295,13 @@ impl CanonicalSerialize for Xsk233Affine {
 
 impl Valid for Xsk233Affine {
     fn check(&self) -> Result<(), SerializationError> {
+        // it is assumed that all points are created from :
+        // a. decode function
+        // b. multipling by a scalar a point like generator point.
+        //
+        // Option b is valid by nature.
+        // Option a has a really intricate mechanism of rejecting invalid points.
         Ok(())
-        //unimplemented!("xsk233-sys does not implement point check")
     }
 }
 

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -33,7 +33,7 @@ use zeroize::Zeroize;
 const COMPRESSED_POINT_SIZE: usize = 30;
 
 /// from xsk233_equals : -1 if two points are equal and 0 if not. This is -1.
-const C_XSK233_EQUALS_TRUE: u32 = 0xFFFFFFFFu32;
+pub(crate) const C_XSK233_EQUALS_TRUE: u32 = 0xFFFFFFFFu32;
 
 /// Affine coordinates for a point on an elliptic curve in short Weierstrass
 /// form, over the base field `P::BaseField`.

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -1,5 +1,7 @@
 use ark_ec::{AffineRepr, CurveConfig, CurveGroup, PrimeGroup};
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, CanonicalSerializeHashExt, Compress, SerializationError, Valid, Validate};
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
 use ark_std::{
     borrow::Borrow,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
@@ -12,18 +14,20 @@ use ark_std::{
     vec::*,
 };
 use std::hash::{Hash, Hasher};
-use std::{fmt, io};
 use std::io::ErrorKind;
 use std::os::raw::c_void;
-use std::collections::hash_map::DefaultHasher;
+use std::{fmt, io};
 
-use ark_ff::{PrimeField, ToConstraintField, fields::Field, AdditiveGroup};
+use ark_ff::{PrimeField, ToConstraintField, fields::Field};
 
 use crate::bigint_to_le_bytes;
 use crate::group::Xsk233Projective;
 use crate::xsk233::Xsk233CurveConfig;
 use educe::Educe;
-use xs233_sys::{xsk233_decode, xsk233_encode, xsk233_equals, xsk233_generator, xsk233_mul_frob, xsk233_neg, xsk233_neutral, xsk233_point};
+use xs233_sys::{
+    xsk233_encode, xsk233_equals, xsk233_generator, xsk233_mul_frob, xsk233_neg, xsk233_neutral,
+    xsk233_point,
+};
 use zeroize::Zeroize;
 
 const COMPRESSED_POINT_SIZE: usize = 30;
@@ -59,7 +63,7 @@ impl PartialEq<Self> for Xsk233Affine {
 
 impl PartialEq<Xsk233Projective> for Xsk233Affine {
     fn eq(&self, other: &Xsk233Projective) -> bool {
-        self == other
+        unsafe { 0xFFFFFFFFu32 == xsk233_equals(self.inner(), other.inner()) }
     }
 }
 
@@ -72,7 +76,8 @@ impl Hash for Xsk233Affine {
 impl Display for Xsk233Affine {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let mut ser = Vec::new();
-        self.serialize_compressed(&mut ser).map_err(|_| fmt::Error)?;
+        self.serialize_compressed(&mut ser)
+            .map_err(|_| fmt::Error)?;
 
         write!(f, "{}", hex::encode(ser))
     }
@@ -81,7 +86,8 @@ impl Display for Xsk233Affine {
 impl Debug for Xsk233Affine {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let mut ser = Vec::new();
-        self.serialize_compressed(&mut ser).map_err(|_| fmt::Error)?;
+        self.serialize_compressed(&mut ser)
+            .map_err(|_| fmt::Error)?;
 
         write!(f, "{}", hex::encode(ser))
     }
@@ -111,9 +117,15 @@ impl AffineRepr for Xsk233Affine {
     type Group = Xsk233Projective;
 
     fn xy(&self) -> Option<(Self::BaseField, Self::BaseField)> {
-        unimplemented!("xsk233-sys crate that is used under the hood does not
+        unimplemented!(
+            "xsk233-sys crate that is used under the hood does not
         allow to operate with x and y concepts. Therefore, there is no direct way in getting
-        x and y coordinates.")
+        x and y coordinates."
+        )
+    }
+
+    fn is_zero(&self) -> bool {
+        unsafe { 0xFFFFFFFFu32 == xsk233_equals(&xsk233_neutral, &self.0) }
     }
 
     #[inline]
@@ -122,15 +134,11 @@ impl AffineRepr for Xsk233Affine {
     }
 
     fn zero() -> Self {
-        unsafe {
-            Self {
-                0: xsk233_neutral
-            }
-        }
+        unsafe { Self(xsk233_neutral) }
     }
 
     fn from_random_bytes(bytes: &[u8]) -> Option<Self> {
-        if let Ok(p) = Xsk233Projective::deserialize_compressed(bytes){
+        if let Ok(p) = Xsk233Projective::deserialize_compressed(bytes) {
             return Some(p.into_affine());
         }
 
@@ -144,7 +152,9 @@ impl AffineRepr for Xsk233Affine {
     /// Multiplies this element by the cofactor and output the
     /// resulting projective element.
     fn mul_by_cofactor_to_group(&self) -> Self::Group {
-        self.mul(Self::ScalarField::from(*Self::Config::COFACTOR.first().unwrap()))
+        self.mul(Self::ScalarField::from(
+            *Self::Config::COFACTOR.first().unwrap(),
+        ))
     }
 
     /// Performs cofactor clearing.
@@ -282,7 +292,8 @@ impl CanonicalSerialize for Xsk233Affine {
 
 impl Valid for Xsk233Affine {
     fn check(&self) -> Result<(), SerializationError> {
-        unimplemented!("xsk233-sys does not implement point check")
+        Ok(())
+        //unimplemented!("xsk233-sys does not implement point check")
     }
 }
 
@@ -299,8 +310,10 @@ impl CanonicalDeserialize for Xsk233Affine {
 impl<ConstraintF: Field> ToConstraintField<ConstraintF> for Xsk233Affine {
     #[inline]
     fn to_field_elements(&self) -> Option<Vec<ConstraintF>> {
-        unimplemented!("xsk233-sys crate that is used under the hood does not
+        unimplemented!(
+            "xsk233-sys crate that is used under the hood does not
         allow to operate with x and y concepts. Therefore, there is no direct way in getting
-        field elements.")
+        field elements."
+        )
     }
 }

--- a/src/affine.rs
+++ b/src/affine.rs
@@ -32,6 +32,9 @@ use zeroize::Zeroize;
 
 const COMPRESSED_POINT_SIZE: usize = 30;
 
+/// from xsk233_equals : -1 if two points are equal and 0 if not. This is -1.
+const C_XSK233_EQUALS_TRUE: u32 = 0xFFFFFFFFu32;
+
 /// Affine coordinates for a point on an elliptic curve in short Weierstrass
 /// form, over the base field `P::BaseField`.
 #[derive(Educe)]
@@ -63,7 +66,7 @@ impl PartialEq<Self> for Xsk233Affine {
 
 impl PartialEq<Xsk233Projective> for Xsk233Affine {
     fn eq(&self, other: &Xsk233Projective) -> bool {
-        unsafe { 0xFFFFFFFFu32 == xsk233_equals(self.inner(), other.inner()) }
+        unsafe { C_XSK233_EQUALS_TRUE == xsk233_equals(self.inner(), other.inner()) }
     }
 }
 
@@ -125,7 +128,7 @@ impl AffineRepr for Xsk233Affine {
     }
 
     fn is_zero(&self) -> bool {
-        unsafe { 0xFFFFFFFFu32 == xsk233_equals(&xsk233_neutral, &self.0) }
+        unsafe { C_XSK233_EQUALS_TRUE == xsk233_equals(&xsk233_neutral, &self.0) }
     }
 
     #[inline]

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,4 +1,4 @@
-use crate::affine::Xsk233Affine;
+use crate::affine::{C_XSK233_EQUALS_TRUE, Xsk233Affine};
 use crate::xsk233::{Fr, Xsk233CurveConfig};
 use crate::{bigint_to_le_bytes, impl_additive_ops_from_ref};
 use ark_ec::short_weierstrass::SWCurveConfig;
@@ -64,13 +64,13 @@ impl Debug for Xsk233Projective {
 impl Eq for Xsk233Projective {}
 impl PartialEq for Xsk233Projective {
     fn eq(&self, other: &Self) -> bool {
-        unsafe { xsk233_equals(self.inner(), other.inner()) != 0 }
+        unsafe { xsk233_equals(self.inner(), other.inner()) == C_XSK233_EQUALS_TRUE }
     }
 }
 
 impl PartialEq<Xsk233Affine> for Xsk233Projective {
     fn eq(&self, other: &Xsk233Affine) -> bool {
-        unsafe { xsk233_equals(self.inner(), other.inner()) != 0 }
+        unsafe { xsk233_equals(self.inner(), other.inner()) == C_XSK233_EQUALS_TRUE }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(trivial_bounds)]
-
 use ark_ff::BigInt;
 
 pub mod affine;

--- a/src/xsk233.rs
+++ b/src/xsk233.rs
@@ -50,7 +50,7 @@ pub const G_GENERATOR_Y: Fq =
 #[cfg(test)]
 mod tests {
     use std::hash::{DefaultHasher, Hash, Hasher};
-    use std::io::{Cursor, Read};
+    use std::io::{Cursor};
     use super::*;
     use crate::affine::Xsk233Affine;
     use crate::bigint_to_le_bytes;
@@ -154,7 +154,6 @@ mod tests {
         unsafe {
             let mut rng = thread_rng();
             let scalar1 = Fr::rand(&mut rng);
-            let scalar2 = Fr::rand(&mut rng);
 
             let p1_xsk = rand_xsk233_sys_point(scalar1);
             let p1_ark = rand_xsk233_ark_point(scalar1);
@@ -179,7 +178,6 @@ mod tests {
         unsafe {
             let mut rng = thread_rng();
             let scalar1 = Fr::rand(&mut rng);
-            let scalar2 = Fr::rand(&mut rng);
 
             let p1_xsk = rand_xsk233_sys_point(scalar1);
             let p1_ark = rand_xsk233_ark_point(scalar1);
@@ -232,8 +230,6 @@ mod tests {
 
     #[test]
     fn test_hashing() {
-        let rng = thread_rng();
-
         let scalar1 = Fr::from(100);
         let g = Xsk233Affine::generator() * scalar1;
 
@@ -245,8 +241,6 @@ mod tests {
 
     #[test]
     fn test_serialization(){
-        let rng = thread_rng();
-
         let scalar1 = Fr::from(100);
         let g = Xsk233Affine::generator() * scalar1;
 

--- a/src/xsk233.rs
+++ b/src/xsk233.rs
@@ -49,8 +49,6 @@ pub const G_GENERATOR_Y: Fq =
 
 #[cfg(test)]
 mod tests {
-    use std::hash::{DefaultHasher, Hash, Hasher};
-    use std::io::{Cursor};
     use super::*;
     use crate::affine::Xsk233Affine;
     use crate::bigint_to_le_bytes;
@@ -59,7 +57,9 @@ mod tests {
     use ark_ff::{AdditiveGroup, PrimeField};
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
     use ark_std::UniformRand;
-    use rand::{thread_rng};
+    use rand::thread_rng;
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    use std::io::Cursor;
     use xs233_sys::{
         xsk233_add, xsk233_double, xsk233_equals, xsk233_generator, xsk233_mul_frob, xsk233_neg,
         xsk233_neutral, xsk233_point,
@@ -240,13 +240,13 @@ mod tests {
     }
 
     #[test]
-    fn test_serialization(){
+    fn test_serialization() {
         let scalar1 = Fr::from(100);
         let g = Xsk233Affine::generator() * scalar1;
 
         let mut res = Vec::new();
         g.serialize_compressed(&mut res).unwrap();
-        
+
         let g_deserialized = Xsk233Affine::deserialize_compressed(Cursor::new(res)).unwrap();
 
         assert_eq!(g, g_deserialized);


### PR DESCRIPTION
1. Made it work with [zkp library](https://github.com/distributed-lab/zkp/tree/arkworks_support):
  - made custom implementation of `is_zero`
  - changed from `unimplemented!(...)` to `Ok(())` in `check` function
2. Fixed some warnings that clippy were generating.
